### PR TITLE
画像ディレクトリをimagesに変更

### DIFF
--- a/images/sample1.png
+++ b/images/sample1.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample10.png
+++ b/images/sample10.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample11.png
+++ b/images/sample11.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample12.png
+++ b/images/sample12.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample13.png
+++ b/images/sample13.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample14.png
+++ b/images/sample14.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample15.png
+++ b/images/sample15.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample2.png
+++ b/images/sample2.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample3.png
+++ b/images/sample3.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample4.png
+++ b/images/sample4.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample5.png
+++ b/images/sample5.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample6.png
+++ b/images/sample6.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample7.png
+++ b/images/sample7.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample8.png
+++ b/images/sample8.png
@@ -1,0 +1,1 @@
+PNG placeholder file

--- a/images/sample9.png
+++ b/images/sample9.png
@@ -1,0 +1,1 @@
+PNG placeholder file


### PR DESCRIPTION
## Summary
- Changed directory name from `image/` to `images/` as requested
- Created 15 PNG placeholder files in the new `images/` directory

## Changes
- Added 15 PNG files (sample1.png - sample15.png) to `images/` directory
- Files are ready to be replaced with actual license-free images

Closes #10

Generated with [Claude Code](https://claude.ai/code)