### PR TITLE
Add night view image to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 </head>
 <body bgcolor="#C0C0C0" text="#000000" link="#0000EE" vlink="#551A8B" alink="#FF0000">
     <center>
+        <img src="images/KAZ88_yorunohibiya_TP_V4.jpg" alt="Night View" width="600" style="border: 3px solid #000080; margin-bottom: 10px;">
+        <br>
         <table border="2" cellpadding="5" cellspacing="0" width="800" bgcolor="#FFFFFF">
             <tr>
                 <td colspan="2" align="center" bgcolor="#000080">


### PR DESCRIPTION
Adds a night view image to the top of the homepage as requested in issue #12.

- Selected KAZ88_yorunohibiya_TP_V4.jpg from /images directory
- Added image at top of page with vintage styling
- Applied 3px blue border and 600px width to match retro theme

Fixes #12

Generated with [Claude Code](https://claude.ai/code)